### PR TITLE
Fix: Update DeviceManagementConfiguration scope and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/cache/
+/reports/

--- a/IntuneDeviceDetailsGUI.ps1
+++ b/IntuneDeviceDetailsGUI.ps1
@@ -3095,7 +3095,7 @@ function Initialize-IntuneSession {
 	$scopes = @(
 		'DeviceManagementManagedDevices.Read.All',
 		'DeviceManagementApps.Read.All',
-		'DeviceManagementConfiguration.Read.All',
+		'DeviceManagementConfiguration.ReadWrite.All',
 		'DeviceManagementServiceConfig.Read.All',
 		'DeviceManagementScripts.Read.All',
 		'User.Read.All',


### PR DESCRIPTION
## Issue
Script fails with 403 Forbidden when fetching encrypted OMA-URI settings

## Root Cause
Microsoft's `getOmaSettingPlainTextValue` endpoint requires `DeviceManagementConfiguration.ReadWrite.All` even for read-only operations, but the script only requested `DeviceManagementConfiguration.Read.All`.

## Changes
- Updated `Connect-MgGraph` scope from `DeviceManagementConfiguration.Read.All` to `DeviceManagementConfiguration.ReadWrite.All`
- Added `.gitignore` to exclude `/cache` and `/reports` directories from version control

## Testing
- Tested on Windows 10 with delegated auth (Connect-MgGraph)
- Script now successfully decrypts OMA-URI secrets and generates extended reports
- All policy information retrieval working without 403 errors